### PR TITLE
Fix Text Domain I18N issue

### DIFF
--- a/app/class-helper.php
+++ b/app/class-helper.php
@@ -23,12 +23,12 @@ class Helper {
 		global $wp_version;
 
 		$setup_statuses = array(
-			'full'              => __( 'The complete full site editing is available. And the theme supports it.', 'disable-fse' ),
-			'full-no-theme'     => __( 'The complete full site editing is available. But the current theme does not support it.', 'disable-fse' ),
-			'template'          => __( 'Custom templates are supported. And the theme supports it.', 'disable-fse' ),
-			'template-no-theme' => __( 'Custom templates are supported. But the current theme does not support it.', 'disable-fse' ),
-			'only-theme'        => __( 'Your theme supports full site editing, install the Gutenberg plugin to use it.', 'disable-fse' ),
-			'nothing'           => __( 'Full site editing is not enabled, to enable install the Gutenberg plugin and a compatible theme like TT1 Blocks.', 'disable-fse' ),
+			'full'              => __( 'The complete full site editing is available. And the theme supports it.', 'disable-full-site-editing' ),
+			'full-no-theme'     => __( 'The complete full site editing is available. But the current theme does not support it.', 'disable-full-site-editing' ),
+			'template'          => __( 'Custom templates are supported. And the theme supports it.', 'disable-full-site-editing' ),
+			'template-no-theme' => __( 'Custom templates are supported. But the current theme does not support it.', 'disable-full-site-editing' ),
+			'only-theme'        => __( 'Your theme supports full site editing, install the Gutenberg plugin to use it.', 'disable-full-site-editing' ),
+			'nothing'           => __( 'Full site editing is not enabled, to enable install the Gutenberg plugin and a compatible theme like TT1 Blocks.', 'disable-full-site-editing' ),
 		);
 		$key            = '';
 

--- a/app/class-settings.php
+++ b/app/class-settings.php
@@ -30,8 +30,8 @@ class Settings {
 	public static function register_menu_page() {
 		add_submenu_page(
 			'tools.php',
-			__( 'Disable Full site editing Settings', 'disable-fse' ),
-			__( 'Disable Full site editing', 'disable-fse' ),
+			__( 'Disable Full site editing Settings', 'disable-full-site-editing' ),
+			_x( 'Disable Full site editing', 'Side Menu Item','disable-full-site-editing' ),
 			'manage_options',
 			'disable-fse',
 			function () {
@@ -61,7 +61,7 @@ class Settings {
 			'disable-fse'
 		);
 
-		$title = __( 'Toggle on/off', 'disable-fse' );
+		$title = __( 'Toggle on/off', 'disable-full-site-editing' );
 		add_settings_field(
 			'disable_fse_status',
 			$title,

--- a/app/template/on-off-switch.php
+++ b/app/template/on-off-switch.php
@@ -28,7 +28,7 @@ if ( defined( 'DISABLE_FSE' ) ) {
 		disabled( $disabled );
 		?>
 	>
-	<label for="disable-fse-on"><?php _e( '<i>Enable</i> site editing ', 'disable-fse' ); ?></label>
+	<label for="disable-fse-on"><?php _e( '<i>Enable</i> site editing', 'disable-full-site-editing' ); ?></label>
 	<br/>
 
 	<input type="radio" id="disable-fse-off" name="disable_fse[status]" value="off"
@@ -38,7 +38,7 @@ if ( defined( 'DISABLE_FSE' ) ) {
 		?>
 
 	>
-	<label for="disable-fse-off"><?php _e( '<i>Disable</i> site editing', 'disable-fse' ); ?></label>
+	<label for="disable-fse-off"><?php _e( '<i>Disable</i> site editing', 'disable-full-site-editing' ); ?></label>
 	<br/>
 
 	<input type="radio" id="disable-fse-or" name="disable_fse[status]" value="or"
@@ -48,14 +48,14 @@ if ( defined( 'DISABLE_FSE' ) ) {
 		?>
 	>
 	<label
-		for="disable-fse-or"><?php _e( 'Respect the <code>WP_ENVIRONMENT_TYPE</code> constant', 'disable-fse' ); ?></label>
+		for="disable-fse-or"><?php _e( 'Respect the <code>WP_ENVIRONMENT_TYPE</code> constant', 'disable-full-site-editing' ); ?></label>
 	<br/>
 	<p class="description" style="padding-left: 2em;">
-		<?php _e( 'Will <i>enable</i> when set to <code>local</code> or <code>development</code>', 'disable-fse' ); ?><br/>
-		<?php _e( 'Will <i>Disable</i> when set to <code>staging</code> or <code>production</code>', 'disable-fse' ); ?><br/>
+		<?php _e( 'Will <i>enable</i> when set to <code>local</code> or <code>development</code>', 'disable-full-site-editing' ); ?><br/>
+		<?php _e( 'Will <i>Disable</i> when set to <code>staging</code> or <code>production</code>', 'disable-full-site-editing' ); ?><br/>
 		<?php
 		// translators: The value for the current wp environment.
-		printf( __( 'Currently set to <code>%s</code>', 'disable-fse' ), wp_get_environment_type() );
+		printf( __( 'Currently set to <code>%s</code>', 'disable-full-site-editing' ), wp_get_environment_type() );
 		?>
 	</p>
 </fieldset>

--- a/app/template/settings-page.php
+++ b/app/template/settings-page.php
@@ -18,25 +18,25 @@ if ( defined( 'DISABLE_FSE' ) ) {
 ?>
 
 <div class="wrap">
-	<h1><?php esc_html_e( 'Disable Full site editing Settings', 'disable-fse' ); ?></h1>
+	<h1><?php esc_html_e( 'Disable Full site editing Settings', 'disable-full-site-editing' ); ?></h1>
 
-	<h2><?php _e( 'Current setup', 'disable-fse' ); ?></h2>
+	<h2><?php _e( 'Current setup', 'disable-full-site-editing' ); ?></h2>
 	<p><?php echo esc_html( Helper::is_fse_setup( false ) ); ?></p>
 
 	<?php if ( defined( 'DISABLE_FSE' ) && (bool) DISABLE_FSE ) : ?>
 		<div class="notice notice-error">
 			<p>
 				<span class="dashicons dashicons-warning"></span>
-				<?php _e( 'The toggle is disabled by the <code>DISABLE_FSE</code> constant.', 'disable-fse' ); ?><br/>
-				<?php _e( 'Full site editing is <strong>enabled</strong>, to re-enable the toggle remove the constant.', 'disable-fse' ); ?>
+				<?php _e( 'The toggle is disabled by the <code>DISABLE_FSE</code> constant.', 'disable-full-site-editing' ); ?><br/>
+				<?php _e( 'Full site editing is <strong>enabled</strong>, to re-enable the toggle remove the constant.', 'disable-full-site-editing' ); ?>
 			</p>
 		</div>
 	<?php elseif ( defined( 'DISABLE_FSE' ) && ! (bool) DISABLE_FSE ) : ?>
 		<div class="notice notice-error">
 			<p>
 				<span class="dashicons dashicons-warning"></span>
-				<?php _e( 'The toggle is disabled by the <code>DISABLE_FSE</code> constant.', 'disable-fse' ); ?><br/>
-				<?php _e( 'Full site editing is <strong>Disabled</strong>, to re-enable the toggle remove the constant.', 'disable-fse' ); ?>
+				<?php _e( 'The toggle is disabled by the <code>DISABLE_FSE</code> constant.', 'disable-full-site-editing' ); ?><br/>
+				<?php _e( 'Full site editing is <strong>Disabled</strong>, to re-enable the toggle remove the constant.', 'disable-full-site-editing' ); ?>
 			</p>
 		</div>
 	<?php endif; ?>
@@ -44,6 +44,6 @@ if ( defined( 'DISABLE_FSE' ) ) {
 	<form action="options.php" method="POST">
 		<?php settings_fields( 'disable-fse-settings' ); ?>
 		<?php do_settings_sections( 'disable-fse' ); ?>
-		<?php submit_button( __( 'Save', 'disable-fse' ), 'primary', 'submit', true, $submit_attr ); ?>
+		<?php submit_button( __( 'Save', 'disable-full-site-editing' ), 'primary', 'submit', true, $submit_attr ); ?>
 	</form>
 </div>

--- a/disable-fse.php
+++ b/disable-fse.php
@@ -5,7 +5,7 @@
  * Description:       Allow disabling full site editing in the admin.
  * Author:            janw.oostendorp
  * Author URI:        https://janw.me
- * Text Domain:       disable-fse
+ * Text Domain:       disable-full-site-editing
  * Domain Path:       /languages
  * Requires at least: 5.0
  * Requires PHP:      7.2


### PR DESCRIPTION
This plugin's slug is **disable-full-site-editing**, but the current Text Domain is set as **disable-fse**. You need to modify the text domain in all your source files.
This PR corrects all Text Domain in source files.